### PR TITLE
Remove support for .zoo format

### DIFF
--- a/DistributionUpdate/PackageUpdate/PackageInfoTools.g
+++ b/DistributionUpdate/PackageUpdate/PackageInfoTools.g
@@ -435,25 +435,6 @@ AddpackageLinesCurrent := function(pkgdir)
   return resstr;
 end;
 
-TextFilesInZooArchive := function(zoofile)
-  local lines, tfiles, l, ll, p;
-  Exec(Concatenation("rm -f tmpzoocomm; zoo lc ", zoofile, " > tmpzoocomm"));
-  lines := SplitString(StringFile("tmpzoocomm"), "", "\n");
-  tfiles := [];
-  for p in [1..Length(lines)] do
-    if Length(lines[p]) >= 8  and lines[p]{[1..8]} = " |!TEXT!" then
-      l := lines[p-1];
-      ll := Length(l);
-      while ll > 0 and l[ll] <> ' ' do
-        ll := ll - 1;
-      od;
-      Add(tfiles, l{[ll+1..Length(l)]});
-    fi;
-  od;
-  Exec("rm -f tmpzoocomm");
-  return tfiles;
-end;
-
 # returns list of dirs with updated archives
 UpdatePackageArchives := function(pkgdir, pkgreposdir, webdir)
   local pkgs, res, nam, info, infostored, infoarchive, url, pos, fname, 
@@ -672,11 +653,6 @@ UpdatePackageArchives := function(pkgdir, pkgreposdir, webdir)
         for a in info.TextBinaryFilesPatterns do
           AppendTo( Concatenation(pkgtmp, "patternstextbinary.txt" ), a, "\n" );
         od;  
-      #elif not ".zoo" in missing then
-        #  tfiles := TextFilesInZooArchive(Concatenation(pkgtmp, fname, ".zoo"));
-        # we could also use the  -win.zip format here, with 'unzip -Z -v'
-        # the text files can be found
-        # elif not -win.zip in missing then .....
       fi;
       
       # classify text/binary files with Max's script classifyfiles.py


### PR DESCRIPTION
This is a companion to gap-system/gap#540, removing all traces of support for the .zoo format.

There is one caveat I am aware of: There is a single package, the ITC package, which is currently only provided as a .zoo.

There are various ways to deal with that.
* We could try to get its maintainer (Volkmar Felsch) to make a new release
* We could try to get permission to migrate the package to GitHub and do the required changes ourselves (similar to what happened to `kbmag` and `cohomolo`)
* We could simply add a workaround, e.g. keep using the .tar.gz files we already have for that package (I am not sure how much work that would require, as I am not intimiately familiar with the actual distribution process)
* ...

