### PR TITLE
Make postrun.sh output usable in .travis.yml files

### DIFF
--- a/testing/postrun.sh
+++ b/testing/postrun.sh
@@ -283,7 +283,12 @@ do
             fi
         fi
     done
-/bin/echo $PKGNAME '|' $PASSA '|' $PASS1 '|' $PASS2
+if [ "${PASS1}" != 'PASS' ] || [ "${PASS2}" != 'PASS' ] || [ "${PASSA}" != 'PASS' ]
+then
+/bin/echo '    - PKG_NAME='$PKGNAME '# default' $PASSA '| no pkg' $PASS1 '| all pkg' $PASS2
+else
+/bin/echo '    - PKG_NAME='$PKGNAME
+fi
 done
 #
 /bin/echo -n "YVALUE=" > dev/log/plotpackages1_count.txt


### PR DESCRIPTION
Previous output had the form
```
Package name | default | no packages | all packages
ace | PASS | PASS | PASS
aclib | PASS | PASS | PASS
alnuth | PASS | PASS | PASS
anupq | PASS | PASS | PASS
atlasrep | 6 DIFFS | 8 DIFFS | 6 DIFFS
autodoc | PASS | PASS | PASS
...
```
in order to paste it to GAP wiki on github. 

First, that wiki page is not in use any more since all information is now visible to package authors in Travis builds using collection of badge in the README file at https://github.com/gap-system/gap-distribution/. 

Second, with the majority of packages having their tests passing, it's hard to see from such table  which packages fail the tests. 

The new output has the form as shown below. It allows to see immediately which tests fail (example below uses the current stable-4.10 branch). The output now can be easily copied and pasted into `.travis.yml` files for Travis CI builds.

```
    - PKG_NAME=ace
    - PKG_NAME=aclib
    - PKG_NAME=alnuth
    - PKG_NAME=anupq
    - PKG_NAME=atlasrep # default 6 DIFFS | no pkg 8 DIFFS | all pkg 6 DIFFS
    - PKG_NAME=autodoc
...
```