### PR TITLE
Show package license

### DIFF
--- a/DistributionUpdate/PackageUpdate/PackageInfoTools.g
+++ b/DistributionUpdate/PackageUpdate/PackageInfoTools.g
@@ -1591,6 +1591,15 @@ AddHTMLPackageInfo := function(arg)
   # SuggestUpgrades  entry
   info.SuggestUpgradesEntry := Concatenation("[ \"", info.PackageName,
        "\", \"", info.Version, "\" ], ");
+
+  # license ...
+  if IsBound(info.License) then
+    Append(res, Concatenation("<h4>License</h4>\n<p>",
+                   "<p><a href='https://spdx.org/licenses/",
+                   info.License,".html'>", info.License,
+                   "</a></p>\n"));
+  fi;
+
   # status
   Append(res, Concatenation("<h4>Status</h4>\n<p>",
               info.Status, "\n"));


### PR DESCRIPTION
This is meant to show the package license, if specified in `PackageInfo.g`, for package pages like https://www.gap-system.org/Packages/gapdoc.html

However, I was not able to test this, as I have no suitable test environment for this code.