### PR TITLE
Add URL for DifSets package

### DIFF
--- a/DistributionUpdate/PackageUpdate/currentPackageInfoURLList
+++ b/DistributionUpdate/PackageUpdate/currentPackageInfoURLList
@@ -55,6 +55,7 @@ cvec        https://gap-packages.github.io/cvec/PackageInfo.g
 datastructures https://gap-packages.github.io/datastructures/PackageInfo.g
 DeepThought https://duskydolphin.github.io/DeepThoughtPackage/PackageInfo.g
 DESIGN      https://gap-packages.github.io/design/PackageInfo.g
+DifSets     https://dylanpeifer.github.io/difsets/PackageInfo.g
 Digraphs    https://gap-packages.github.io/Digraphs/PackageInfo.g
 EDIM        http://www.math.rwth-aachen.de/~Frank.Luebeck/EDIM/PackageInfo.g
 Example     https://gap-packages.github.io/example/PackageInfo.g


### PR DESCRIPTION
This adds the PackageInfo.g URL for the recently accepted DifSets package to `DistributionUpdate/PackageUpdate/currentPackageInfoURLList`.