### PR TITLE
Add overview of license types to the report

### DIFF
--- a/DistributionUpdate/PackageUpdate/healthcheck.g
+++ b/DistributionUpdate/PackageUpdate/healthcheck.g
@@ -46,6 +46,20 @@ for x in  Collected(List(dates,x->x[3])) do
 od;
 Print("\n");
 
+# SPDX license identifier in PackageInfo.g
+
+haveSPDXinfo := Filtered( pkgnames, n -> IsBound( GAPInfo.PackagesInfo.(n)[1].License));
+lackSPDXinfo := Filtered( pkgnames, n -> not IsBound( GAPInfo.PackagesInfo.(n)[1].License));
+
+Print("*** ", Length(haveSPDXinfo), " packages have SPDX license identifier in PackageInfo.g\n");
+Print("*** ", Length(lackSPDXinfo), " packages have no SPDX license identifier in PackageInfo.g\n\n");
+
+Print("*** Licence types, when SPDX license identifier provided:\n");
+for x in  Collected( List( haveSPDXinfo, n -> GAPInfo.PackagesInfo.(n)[1].License) ) do
+  Print(x[2], " : ", x[1], "\n");
+od;
+Print("\n");
+
 # Test files
 
 havetests := Filtered( pkgnames, n -> IsBound( GAPInfo.PackagesInfo.(n)[1].TestFile));


### PR DESCRIPTION
It now shows this:
```
*** 90 packages have SPDX license identifier in PackageInfo.g
*** 58 packages have no SPDX license identifier in PackageInfo.g

*** Licence types, when SPDX license identifier provided:
1 : Artistic-2.0
1 : BSD-3-Clause
1 : GPL-2.0 OR GPL-3.0
72 : GPL-2.0-or-later
1 : GPL-3.0
9 : GPL-3.0-or-later
3 : MIT
1 : MPL-2.0
1 : none
```
"none" is from anupq, see https://github.com/gap-packages/anupq/issues/34
