### PR TITLE
testing: don't hardcode GAP arch in scripts

### DIFF
--- a/testing/master/GAP-major-release-win-build.sh
+++ b/testing/master/GAP-major-release-win-build.sh
@@ -15,6 +15,9 @@ cd /cygdrive/c/${DISTNAME}
 ./configure
 make
 
+# extract GAP build settings like GAParch
+source sysinfo.gap
+
 # BUILDING PACKAGES
 
 cd pkg
@@ -29,14 +32,14 @@ cd ..
 # END OF BUILDING PACKAGES
 
 cd bin
-sed -i 's/cygwin\\bin/'"${DISTNAME}"'\\bin\\i686-pc-cygwin-default32-kv6/g' gap.bat
-sed -i 's/cygwin\\bin/'"${DISTNAME}"'\\bin\\i686-pc-cygwin-default32-kv6/g' gapcmd.bat
-sed -i 's/cygwin\\bin/'"${DISTNAME}"'\\bin\\i686-pc-cygwin-default32-kv6/g' gaprxvt.bat
+sed -i 's/cygwin\\bin/'${DISTNAME}'\\bin\\'${GAParch}'/g' gap.bat
+sed -i 's/cygwin\\bin/'${DISTNAME}'\\bin\\'${GAParch}'/g' gapcmd.bat
+sed -i 's/cygwin\\bin/'${DISTNAME}'\\bin\\'${GAParch}'/g' gaprxvt.bat
 cd ..
 
 bin/instcygwinterminfo.sh
-cp /bin/cyggcc_s-1.dll /bin/cyggmp-10.dll /bin/cygncursesw-10.dll /bin/cygpanelw-10.dll /bin/cygpopt-0.dll /bin/cygreadline7.dll /bin/cygstart.exe /bin/cygstdc++-6.dll /bin/cygwin1.dll /bin/mintty.exe /usr/bin/cygz.dll /usr/bin/rxvt.exe /usr/bin/regtool.exe /usr/i686-w64-mingw32/sys-root/mingw/bin/zlib1.dll bin/i686-pc-cygwin-default32-kv6
-cp /bin/cygcurl* /bin/cygidn* /bin/cygcrypto* /bin/cyggssapi* /bin/cyglber* /bin/cygldap* /bin/cygssh* /bin/cygssl* /bin/cygkrb* /bin/cygk5crypto* /bin/cygintl* /bin/cygcom_err* /bin/cygunistring* /bin/cygiconv* /bin/cygsasl* bin/i686-pc-cygwin-default32-kv6
+cp /bin/cyggcc_s-1.dll /bin/cyggmp-10.dll /bin/cygncursesw-10.dll /bin/cygpanelw-10.dll /bin/cygpopt-0.dll /bin/cygreadline7.dll /bin/cygstart.exe /bin/cygstdc++-6.dll /bin/cygwin1.dll /bin/mintty.exe /usr/bin/cygz.dll /usr/bin/rxvt.exe /usr/bin/regtool.exe /usr/i686-w64-mingw32/sys-root/mingw/bin/zlib1.dll bin/${GAParch}
+cp /bin/cygcurl* /bin/cygidn* /bin/cygcrypto* /bin/cyggssapi* /bin/cyglber* /bin/cygldap* /bin/cygssh* /bin/cygssl* /bin/cygkrb* /bin/cygk5crypto* /bin/cygintl* /bin/cygcom_err* /bin/cygunistring* /bin/cygiconv* /bin/cygsasl* bin/${GAParch}
 cd ..
 zip -qq -r $WORKSPACE/${ARCHNAME}-win.zip ${DISTNAME}
 cp $WORKSPACE/${ARCHNAME}-win.zip $WORKSPACE/gap-major-win.zip

--- a/testing/stable/GAP-minor-release-win-build.sh
+++ b/testing/stable/GAP-minor-release-win-build.sh
@@ -15,6 +15,9 @@ cd /cygdrive/c/${DISTNAME}
 ./configure
 make
 
+# extract GAP build settings like GAParch
+source sysinfo.gap
+
 # BUILDING PACKAGES
 
 cd pkg
@@ -29,14 +32,14 @@ cd ..
 # END OF BUILDING PACKAGES
 
 cd bin
-sed -i 's/cygwin\\bin/'"${DISTNAME}"'\\bin\\i686-pc-cygwin-default32-kv3/g' gap.bat
-sed -i 's/cygwin\\bin/'"${DISTNAME}"'\\bin\\i686-pc-cygwin-default32-kv3/g' gapcmd.bat
-sed -i 's/cygwin\\bin/'"${DISTNAME}"'\\bin\\i686-pc-cygwin-default32-kv3/g' gaprxvt.bat
+sed -i 's/cygwin\\bin/'${DISTNAME}'\\bin\\'${GAParch}'/g' gap.bat
+sed -i 's/cygwin\\bin/'${DISTNAME}'\\bin\\'${GAParch}'/g' gapcmd.bat
+sed -i 's/cygwin\\bin/'${DISTNAME}'\\bin\\'${GAParch}'/g' gaprxvt.bat
 cd ..
 
 bin/instcygwinterminfo.sh
-cp /bin/cyggcc_s-1.dll /bin/cyggmp-10.dll /bin/cygncursesw-10.dll /bin/cygpanelw-10.dll /bin/cygpopt-0.dll /bin/cygreadline7.dll /bin/cygstart.exe /bin/cygstdc++-6.dll /bin/cygwin1.dll /bin/mintty.exe /usr/bin/cygz.dll /usr/bin/rxvt.exe /usr/bin/regtool.exe /usr/i686-w64-mingw32/sys-root/mingw/bin/zlib1.dll bin/i686-pc-cygwin-default32-kv3
-cp /bin/cygcurl* /bin/cygidn* /bin/cygcrypto* /bin/cyggssapi* /bin/cyglber* /bin/cygldap* /bin/cygssh* /bin/cygssl* /bin/cygkrb* /bin/cygk5crypto* /bin/cygintl* /bin/cygcom_err* /bin/cygunistring* /bin/cygiconv* /bin/cygsasl* /bin/cygnghttp2* /bin/cygpsl* /bin/cygzmq* /bin/cygsodium* bin/i686-pc-cygwin-default32-kv3
+cp /bin/cyggcc_s-1.dll /bin/cyggmp-10.dll /bin/cygncursesw-10.dll /bin/cygpanelw-10.dll /bin/cygpopt-0.dll /bin/cygreadline7.dll /bin/cygstart.exe /bin/cygstdc++-6.dll /bin/cygwin1.dll /bin/mintty.exe /usr/bin/cygz.dll /usr/bin/rxvt.exe /usr/bin/regtool.exe /usr/i686-w64-mingw32/sys-root/mingw/bin/zlib1.dll bin/${GAParch}
+cp /bin/cygcurl* /bin/cygidn* /bin/cygcrypto* /bin/cyggssapi* /bin/cyglber* /bin/cygldap* /bin/cygssh* /bin/cygssl* /bin/cygkrb* /bin/cygk5crypto* /bin/cygintl* /bin/cygcom_err* /bin/cygunistring* /bin/cygiconv* /bin/cygsasl* /bin/cygnghttp2* /bin/cygpsl* /bin/cygzmq* /bin/cygsodium* bin/${GAParch}
 cd ..
 zip -qq -r $WORKSPACE/${ARCHNAME}-win.zip ${DISTNAME}
 cp $WORKSPACE/${ARCHNAME}-win.zip $WORKSPACE/gap-minor-win.zip


### PR DESCRIPTION
This used to be part of PR #89

There are a couple more hardcoded arch strings left, in these files:
- `testing/master/gaptest.bat`
- `testing/stable/gaptest.bat`
- `testing/stable/gaptest64.bat`

However, I wonder if those files are used at all, because they do not contain the `-kv3` resp. `-kv6` bits. If they are not used, let's remove them from the repo. If they are used, why do they work? If they don't need the `-kv?` bit for some reason, then we can probably just leave them as they are, as they then really don't depend on the `-kv?` bit in the GAP arch string.